### PR TITLE
Allow players in the lobby to see their own messages

### DIFF
--- a/src/main/java/vc/pvp/skywars/listeners/PlayerListener.java
+++ b/src/main/java/vc/pvp/skywars/listeners/PlayerListener.java
@@ -107,10 +107,6 @@ public class PlayerListener implements Listener {
 
         } else {
             for (GamePlayer gp : PlayerController.get().getAll()) {
-                if (gp.equals(gamePlayer)) {
-                    continue;
-                }
-
                 if (!gp.isPlaying()) {
                     gp.getBukkitPlayer().sendMessage(message);
                 }


### PR DESCRIPTION
Why send the message to everyone in the lobby but the player themselves?  Since you're canceling the event, they otherwise get no feedback that their message appeared in chat.
